### PR TITLE
GH-1 TypeError when opening shapefiles.

### DIFF
--- a/gh.py
+++ b/gh.py
@@ -82,7 +82,7 @@ class GisHelper(QtWidgets.QMainWindow, Ui_MainWindow):
         :return:
         """
 
-        openfile = QtWidgets.QFileDialog.getOpenFileName(self)
+        openfile = QtWidgets.QFileDialog.getOpenFileName(self)[0]  # This now returns a tuple as of Qt5
         self.shapefileViewPath.setText(openfile)
 
     def browse_for_raster(self):


### PR DESCRIPTION
Use 0th index of getOpenFileName result to pass to setText.