### PR TITLE
GIS-Helper-27 Conda create sometimes fails when running Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
             }
             steps {
                 bat 'conda env remove -y --name GIS-Helper'
+                sleep(time:30,unit:"SECONDS")  // Check to see if environment is being fully removed
                 bat 'conda env create' // Build environment based on environment.yml
                 bat 'conda activate GIS-Helper'
                 bat 'c:\\Users\\Ross\\anaconda3\\envs\\GIS-Helper\\Scripts\\pyinstaller --onefile gh-debug.spec'


### PR DESCRIPTION
Pause pipeline after conda env remove to check if GIT-Helper directory is being fully removed.