### PR TITLE
GIS-Helper-27 Conda create sometimes fails when running Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             }
             steps {
                 bat 'conda env remove -y --name GIS-Helper'
-                bat 'rmdir c:\\Users\Ross\anaconda3\\envs\GIS-Helper'  // Make sure environment is fully gone
+                bat 'rmdir c:\\Users\\Ross\\anaconda3\\envs\\GIS-Helper'  // Make sure environment is fully gone
                 sleep(time:30,unit:"SECONDS")  // Check to see if environment is being fully removed
                 bat 'conda env create' // Build environment based on environment.yml
                 bat 'conda activate GIS-Helper'


### PR DESCRIPTION
Escaped `\` in Jenknsfile step.