### PR TITLE
GIS-Helper-27 Conda create sometimes fails when running Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 }
                 cleanup {
                     bat 'conda env remove -y --name GIS-Helper'
-                    bat 'rmdir /S c:\\Users\\Ross\\anaconda3\\envs\\GIS-Helper'  // Make sure environment is fully gone
+                    bat 'rmdir /Q /S c:\\Users\\Ross\\anaconda3\\envs\\GIS-Helper'  // Make sure environment is fully gone
                     cleanWs()
                 }
             }


### PR DESCRIPTION
Add `/Q` flag to rmdir to delete without confirmation.